### PR TITLE
Fix backdrop with stacking visible modals

### DIFF
--- a/src/lib/Modals.svelte
+++ b/src/lib/Modals.svelte
@@ -10,12 +10,12 @@
   }
 </script>
 
-{#if $modals.length > 0}
-  <slot name="backdrop" />
-{/if}
 
 <slot>
   {#each $modals as modal, i (i)}
+    {#if $modals.length - 1 === i}
+      <slot name="backdrop" />
+    {/if}
     <!-- lazy modal -->
     {#if isLazyModal(modal.component)}
       {#await getComponent(modal.component)}


### PR DESCRIPTION
Previously if I wanted to stack modals, the backdrop would always be behind the first modal. Now it behaves properly if `isOpen` is not used. Behavior does not change when modals are not stacked.

I can add an example to the docs if needed