### PR TITLE
Fix import order in Modals.svelte

### DIFF
--- a/src/lib/Modals.svelte
+++ b/src/lib/Modals.svelte
@@ -1,4 +1,5 @@
 <script lang="ts" module>
+  import { ModalStack } from './modal-stack.svelte'
   export const modals = new ModalStack()
 
   export interface ModalsProps {
@@ -21,7 +22,6 @@
   import type { Snippet } from 'svelte'
   import StackedModalContext from './StackedModalContext.svelte'
   import type { ModalProps } from './stacked-modal.svelte'
-  import { ModalStack } from './modal-stack.svelte'
   import type { LazyModalComponent, ModalComponent } from './types'
 
   function isLazyModal(


### PR DESCRIPTION
As per the svelte documentation, variables in a normal script tag is not exposed to module scripts

<img width="871" alt="image" src="https://github.com/user-attachments/assets/5e9eea9a-075f-4fa6-8831-2bc1aab91720" />
<img width="2056" alt="image" src="https://github.com/user-attachments/assets/1c15abe1-1f6c-4746-8b7b-5f9679d783e3" />
